### PR TITLE
Align MHD with carrow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,7 @@
-- Align MHD with carrow.
++ Align MHD with carrow.
+  + Is listen_fd exists in fdsets?
+  + How really MHD_run(&d) distinguishes between ready fds and not-ready-yet
+    fds?
 - Get rid of m4
 - Get rid of automake and use CMake instead.
 - Remove win32 directory and everything about Micro$oft windows.

--- a/carrow_microhttpd.c
+++ b/carrow_microhttpd.c
@@ -11,6 +11,7 @@ typedef struct carrow_microhttpd {
     struct MHD_Daemon *daemon;
 } carrow_microhttpd;
 
+
 #undef CARROW_ENTITY
 #define CARROW_ENTITY carrow_microhttpd
 #include <carrow_generic.h>

--- a/carrow_microhttpd.c
+++ b/carrow_microhttpd.c
@@ -1,0 +1,119 @@
+// Copyright 2023 Vahid Mardani
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/timerfd.h>
+#include <microhttpd.h>
+#include <clog.h>
+#include <carrow.h>
+
+
+typedef struct carrow_microhttpd {
+    struct MHD_Daemon *daemon;
+} carrow_microhttpd;
+
+#undef CARROW_ENTITY
+#define CARROW_ENTITY carrow_microhttpd
+#include <carrow_generic.h>
+#include <carrow_generic.c>
+
+
+static enum MHD_Result
+request_handler(
+    void *cls,
+    struct MHD_Connection *connection,
+    const char *url,
+    const char *method,
+    const char *version,
+    const char *upload_data,
+    size_t *upload_data_size,
+    void **req_cls
+) {
+    struct MHD_Response *response;
+    enum MHD_Result ret;
+
+    response = MHD_create_response_from_buffer(
+        strlen(url),
+        (void *) url,
+        MHD_RESPMEM_PERSISTENT);
+    ret = MHD_queue_response(
+        connection,
+        MHD_HTTP_OK,
+        response);
+
+    MHD_destroy_response(response);
+    return ret;
+}
+
+
+static void
+httpserverA(
+    struct carrow_microhttpd_coro *self,
+    struct carrow_microhttpd *state
+) {
+    fd_set rs;
+    fd_set ws;
+    fd_set es;
+    int i;
+
+    CORO_START;
+
+    while (true) {
+        FD_ZERO(&rs);
+        FD_ZERO(&ws);
+        FD_ZERO(&es);
+
+        if (MHD_get_fdset(state->daemon, &rs, &ws, &es, NULL) != MHD_YES) {
+            CORO_REJECT("MHD_get_fdset failed.");
+        }
+
+        for (i = 0; i < FD_SETSIZE; i++) {
+            if (FD_ISSET(i, &rs)) {
+                CORO_WAIT(i, CIN);
+
+                FD_ZERO(&rs);
+                FD_SET(i, &rs);
+
+                if (MHD_run(state->daemon) != MHD_YES) {
+                    CORO_REJECT("MHD_run failed.");
+                }
+
+                break;  // only one fd we are interested in
+            }
+        }
+    }
+
+    CORO_FINALLY;
+    MHD_stop_daemon(state->daemon);
+    CORO_END;
+}
+
+
+int
+main() {
+    struct MHD_Daemon *d;
+    int port;
+
+    port = 8080;
+    clog_verbosity = CLOG_DEBUG;
+
+    d = MHD_start_daemon(
+        MHD_USE_DEBUG,
+        port,
+        NULL,
+        NULL,
+        &request_handler,
+        NULL,
+        MHD_OPTION_END);
+    if (d == NULL) {
+        ERROR("Could not start daemon on port %d.\n", port);
+        return 1;
+    }
+
+    INFO("Listening on port %d...\n", port);
+
+    struct carrow_microhttpd state = {
+        .daemon = d
+    };
+
+    return carrow_microhttpd_forever(httpserverA, &state, NULL);
+}


### PR DESCRIPTION
All linting issues got resolved except the following which is nonsense to me.

```bash
carrow_microhttpd.c:88:  Closing brace should be aligned with beginning of struct carrow_microhttpd_coro  [whitespace/indent] [3]
Total errors found: 1
```